### PR TITLE
Support UDP payloads and handlers

### DIFF
--- a/lib/rex/io/ring_buffer.rb
+++ b/lib/rex/io/ring_buffer.rb
@@ -285,6 +285,32 @@ class RingBuffer
 
 end
 
+class RingBufferUdp < RingBuffer
+
+  #
+  # The built-in monitor thread (normally unused with Metasploit)
+  #
+  def monitor_thread
+    Thread.new do
+      begin
+      while self.fd
+        begin
+          buff = self.fd.recvfrom_nonblock(1.0)
+        rescue  IO::WaitReadable
+          # IO.select([self.fd])
+          next
+        end
+        next if not buff
+        store_data(buff)
+      end
+      rescue ::Exception => e
+        self.monitor_thread_error = e
+      end
+    end
+  end
+
+end
+
 end
 end
 
@@ -365,5 +391,3 @@ c = r.create_stream
 p c.read
 
 =end
-
-


### PR DESCRIPTION
## Introduce RingBufferUdp, a monitored RingBuffer

This breakout of the original UDP handlers and paylaods PR (6035)
contains the rex/io component, subclassing the RingBuffer to allow
monitoring of the instance much as we do with socket abstractions
and other polling mechanisms.