### PR TITLE
clean_path() should not mutate its args

### DIFF
--- a/lib/rex/file.rb
+++ b/lib/rex/file.rb
@@ -66,7 +66,7 @@ module FileUtils
   # but clean ../something as well as path/with/..\traversal
   #
   def self.clean_path(old)
-    path = old
+    path = old.dup
     while(path.index(/\/..\/|\/..\\|\\..\\|\\..\/|\A..\\|\A..\//) != nil)
       path.gsub!(/\A..\\|\A..\//,'') #eliminate starting ..\ or ../
       path.gsub!(/\/..\/|\/..\\/,'/') #clean linux style


### PR DESCRIPTION
NB: Probably need to consider if anything is relying on the "broken" behaviour the function currently exhibits. Code that calls `clean_path()` should consume the return value and should not assume that `clean_path()` mutates its arguments (i.e. code should not treat a variable as safe if it has simply called `clean_path()` on it)

`clean_path()` currently mutates its args:

```
% ./bin/console
irb(main):001:0> foo = '/hello/../world'
=> "/hello/../world"
irb(main):002:0> foo_cleaned = Rex::FileUtils.clean_path(foo)
=> "/hello/world"
irb(main):003:0> puts foo_cleaned
/hello/world
=> nil
irb(main):004:0> puts foo
/hello/world
=> nil
```

I don't think it's supposed to be mutating its args.

After the patch:

```
% ./bin/console 
irb(main):001:0> foo = '/hello/../world'
=> "/hello/../world"
irb(main):002:0> foo_cleaned = Rex::FileUtils.clean_path(foo)
=> "/hello/world"
irb(main):003:0> puts foo_cleaned
/hello/world
=> nil
irb(main):004:0> puts foo
/hello/../world
=> nil
```