### PR TITLE
Escape dots in clean_path()'s regexes

### DIFF
--- a/lib/rex/file.rb
+++ b/lib/rex/file.rb
@@ -67,11 +67,17 @@ module FileUtils
   #
   def self.clean_path(old)
     path = old.dup
-    while(path.index(/\/..\/|\/..\\|\\..\\|\\..\/|\A..\\|\A..\//) != nil)
-      path.gsub!(/\A..\\|\A..\//,'') #eliminate starting ..\ or ../
-      path.gsub!(/\/..\/|\/..\\/,'/') #clean linux style
-      path.gsub!(/\\..\\|\\..\//,'\\') #clean windows style
+
+    leading       = /\A\.\.\\|\A\.\.\//   # '..\'  or '../'  at start of string
+    linux_style   = /\/\.\.\/|\/\.\.\\/   # '/../' or '/..\'
+    windows_style = /\\\.\.\\|\\\.\.\//   # '\..\' or '\../'
+
+    while(path.index(leading) != nil or path.index(linux_style) != nil or path.index(windows_style) != nil)
+      path.gsub!(leading,'')
+      path.gsub!(linux_style,'/')
+      path.gsub!(windows_style,'\\')
     end
+
     path
   end
 

--- a/spec/rex/file_spec.rb
+++ b/spec/rex/file_spec.rb
@@ -62,5 +62,31 @@ describe Rex::FileUtils do
     it 'eliminates leading traversals from a windows path' do
       expect(Rex::FileUtils.clean_path('..\foo\home')).to eq 'foo\home'
     end
+
+    it 'eliminates embedded traversals from a linux path' do
+      expect(Rex::FileUtils.clean_path('foo/../home')).to eq 'foo/home'
+    end
+
+    it 'eliminates embedded traversals from a windows path' do
+      expect(Rex::FileUtils.clean_path('foo\..\home')).to eq 'foo\home'
+    end
+
+    it 'eliminates mixed traversals from a linux path' do
+      expect(Rex::FileUtils.clean_path('../foo/..\home')).to eq 'foo/home'
+      expect(Rex::FileUtils.clean_path('..\foo/..\home')).to eq 'foo/home'
+    end
+
+    it 'eliminates mixed traversals from a windows path' do
+      expect(Rex::FileUtils.clean_path('..\foo\../home')).to eq 'foo\home'
+      expect(Rex::FileUtils.clean_path('../foo\../home')).to eq 'foo\home'
+    end
+
+    it 'does not eliminate valid dirnames from a linux path' do
+      expect(Rex::FileUtils.clean_path('foo/ZZ/home')).to eq 'foo/ZZ/home'
+    end
+
+    it 'does not eliminate valid dirnames from a windows path' do
+      expect(Rex::FileUtils.clean_path('foo\ZZ\home')).to eq 'foo\ZZ\home'
+    end
   end
 end


### PR DESCRIPTION
`clean_path()`'s regexes have unescaped dots, causing unintended over-cleaning.

Before patch:

```
irb(main):003:0> ::Rex::FileUtils::clean_path('a/b/../c')                                                                                                                                                                                                                                   
=> "a/b/c"
```
This is good

```
irb(main):004:0> ::Rex::FileUtils::clean_path('a/b/ZZ/c')                                                                                                                                                                                                                                   
=> "a/b/c"
```

This is bad

Post-patch:

```
irb(main):002:0> ::Rex::FileUtils::clean_path('a/b/../c')
=> "a/b/c"
irb(main):003:0> ::Rex::FileUtils::clean_path('a/b/ZZ/c')
=> "a/b/ZZ/c"
irb(main):004:0> ::Rex::FileUtils::clean_path('a/b/..\\c')                                                                                                                                                                                                                                  
=> "a/b/c"
irb(main):005:0> ::Rex::FileUtils::clean_path('../a/b/..\\c')                                                                                                                                                                                                                               
=> "a/b/c"
irb(main):006:0> ::Rex::FileUtils::clean_path('..\\a/b/..\\c')                                                                                                                                                                                                                              
=> "a/b/c"
```