### PR TITLE
Remove tainted calls

### DIFF
--- a/lib/rex/file.rb
+++ b/lib/rex/file.rb
@@ -130,7 +130,7 @@ module Find
     paths.collect!{|d| d.dup}
     while file = paths.shift
       catch(:prune) do
-        yield file.dup.taint
+        yield file.dup
         next unless File.exist? file
         begin
           if File.stat(file).directory? then
@@ -145,7 +145,7 @@ module Find
                 else
                   f = File.join(file, f)
                 end
-                paths.unshift f.untaint
+                paths.unshift f
               end
             ensure
               d.close


### PR DESCRIPTION
The Ruby core team has deprecated the taint mechanism in Ruby 2.7 and will remove it in Ruby 3.2

> Ruby had Taint checking which is originally introduced in Perl.
> https://en.wikipedia.org/wiki/Taint_checking
> 
> It was intended to provide a useful tool for handle objects which are come from outside.
> Input data is set as tainted by default and call untaint if you checked or filtered the value.
> Some people used this feature in the age of CGI.
> 
> But these days, no one use the mechanism and input libraries usually doesn't support it.
> - https://bugs.ruby-lang.org/issues/16131

In Ruby 2.7 this functionality is now noop:

```diff
  VALUE
  rb_obj_taint(VALUE obj)
  {
-     if (!OBJ_TAINTED(obj) && OBJ_TAINTABLE(obj)) {
-        rb_check_frozen(obj);
-        OBJ_TAINT(obj);
-     }
+     rb_warning("Object#taint is deprecated and will be removed in Ruby 3.2.");
      return obj;
  }
```

Associated Ruby core code change: https://github.com/ruby/ruby/pull/2476

Example warnings:

> /Users/user/.rvm/gems/ruby-2.7.0/gems/rex-core-0.1.14/lib/rex/file.rb:133: warning: Object#taint is deprecated and will be removed in Ruby 3.2.
> /Users/user/.rvm/gems/ruby-2.7.0/gems/rex-core-0.1.14/lib/rex/file.rb:133: warning: Object#taint is deprecated and will be removed in Ruby 3.2.
> /Users/user/.rvm/gems/ruby-2.7.0/gems/rex-core-0.1.14/lib/rex/file.rb:148: warning: Object#untaint is deprecated and will be removed in Ruby 3.2.
> /Users/user/.rvm/gems/ruby-2.7.0/gems/rex-core-0.1.14/lib/rex/file.rb:133: warning: Object#taint is deprecated and will be removed in Ruby 3.2.
```

https://github.com/rapid7/metasploit-framework/issues/14666