### PR TITLE
Synchronize access to streams

### DIFF
--- a/lib/rex/io/stream_abstraction.rb
+++ b/lib/rex/io/stream_abstraction.rb
@@ -19,9 +19,13 @@ module StreamAbstraction
   #
   def initialize_abstraction
     self.lsock, self.rsock = Rex::Socket.tcp_socket_pair()
+
     self.lsock.extend(Rex::IO::Stream)
     self.lsock.extend(Ext)
     self.rsock.extend(Rex::IO::Stream)
+
+    self.lsock.initialize_synchronization
+    self.rsock.initialize_synchronization
 
     self.monitor_rsock("StreamMonitorRemote")
   end


### PR DESCRIPTION
This synchronizes access to streams such that they can not be closed while there is a blocking read or write operation that has pending data. The synchronization has to be initialized in order to be activated and that should be setup in cases where the stream object will be written to and read or closed from more than one thread. In the context of Metasploit, this is the case with pivoted sockets, where the module or whatever has the socket and is probably reading or writing from it, however the Meterpreter Packet Dispatcher can close the stream in response to a channel_close request received by the remote Meterpreter instance. The remote Meterpreter instance would issue a channel_close request in response to the peer having closed it so that event is propagated to Metasploit.

Without this synchronization in place, it's possible that a blocking `#read` call may lose data when the remote peer (and Meterpreter instance by proxy) has written data to the channel and then closed it. This is a common pattern with HTTP requests, where after the client has issued the request, the server will respond and immediately close the connection. Without synchronization in place, this HTTP response can be lost.

This fixes rapid7/metasploit-framework#14668

## Testing Steps

- [ ] Open a Meterpreter instance, I did most of my testing with mettle but I know the Python implementation was affected as well. Windows seemed to be more difficult to reproduce this issue on though I didn't investigate it indepth.
- [ ] Route all of your traffic through your meterpreter session by running `route add 0.0.0.0 -1`
- [ ] Use the `connect` framework command (from `msf >` **not** `meterpreter >`) and issue a raw HTTP request to `metasploit.com` on port 80
    * `GET / HTTP/1.0`
- [ ] See the server respond with a `"400 Bad Request" and close the connection
    * To reproduce the original issue repeat these steps, however at this point note that ~4/5 times the server response will not be read
- [ ] Repeat the last step multiple times to see that the results are consistent, indicating that a successful read no longer requires a race condition to be won

## A note on the Read Write Lock
The stream's read and write function utilize the lock's read synchronization. This is because reading and writing to the stream do not alter the state of the stream and in theory, one thread can be reading from the stream while another writes to it and there won't be any issues. The close function however utilizes the lock's write synchronization because it does alter the state of the stream. When other threads are reading and writing from the stream, the close operation will disrupt them. To make the code a bit more readable, I map the stream methods `#synchronize_access` (as used by `#read` and `#write`) to the locks `#synchronize_read` function while `#synchronize_update` uses the lock's `#synchronize_write` function. I tried to document this in the code for clarity as well.