### PR TITLE
Make write a blocking action to fix portfwd

### DIFF
--- a/lib/rex/io/stream.rb
+++ b/lib/rex/io/stream.rb
@@ -61,7 +61,7 @@ module Stream
             next
           end
           data = buf[total_sent, block_size]
-          sent = fd.write_nonblock( data )
+          sent = fd.syswrite( data )
           if sent > 0
             total_sent += sent
           end


### PR DESCRIPTION
This PR addresses an issue with framework where port forwarding via meterpreter was inconsistent and often would not send all of the requested data through

# Replication steps:
- [x] Get a meterpreter session (any will do, tested with mettle, windows meterpreter and python meterpreter)
- [x] Add a portforwarding rule i.e. `portfwd add -R -l 5555 -L 127.0.0.1 -p 5555` (reverse port forward that directs all remote traffic on port 5555 to localhost 5555)
- [x] Run a web server on your localhost on port 5555 i.e. `python3 -m http.server 5555`
- [x] curl port 5555 on the remote host, multiple times
- [x] You should see intermittent failures

# Cause
When there is nothing left to read from the webservice this line here
https://github.com/rapid7/metasploit-framework/blob/7fbbe23426cacbf810f9bdde047f6ae4ebebadd8/lib/rex/services/local_relay.rb#L515 throws an end of file error.
This is normal and to be expected. What happens next is this triggers the channel to close and there is a race condition where the channel can close before all the data has been sent
This PR solves that problem by making writing to the channel a blocking operation so the channel cannot be closed before all data has been written.

Not sure at all if this is a good way of resolving this issue so I'm putting this out there for some feedback and for any ideas other people may have.
