### PR TITLE
Make the synchronization functions public

### DIFF
--- a/lib/rex/io/stream.rb
+++ b/lib/rex/io/stream.rb
@@ -325,21 +325,6 @@ module Stream
     16384
   end
 
-protected
-
-  #
-  # The read-write lock used to synchronize access to the stream. This is only
-  # set when synchronization has been initialized as performed by
-  # #initialize_synchronization.
-  #
-  attr_accessor :stream_lock
-
-  #
-  # A boolean flag indicating that the resource is to be closed. Blocking
-  # operations that are synchronized (such as #read and #write) should evaluate
-  # this flag and exit appropriately when there is no data to be processed.
-  attr_accessor :close_resource
-
   #
   # Synchronize non-state changing access to the stream such as read and write
   # operations. If synchronization has not been initialized, this doesn't do
@@ -366,6 +351,21 @@ protected
       self.stream_lock.unlock_write unless self.stream_lock.nil?
     end
   end
+
+protected
+
+  #
+  # The read-write lock used to synchronize access to the stream. This is only
+  # set when synchronization has been initialized as performed by
+  # #initialize_synchronization.
+  #
+  attr_accessor :stream_lock
+
+  #
+  # A boolean flag indicating that the resource is to be closed. Blocking
+  # operations that are synchronized (such as #read and #write) should evaluate
+  # this flag and exit appropriately when there is no data to be processed.
+  attr_accessor :close_resource
 end
 
 end end


### PR DESCRIPTION
This makes the `synchronize_access` and `synchronize_update` methods provided by the stream module public which allows them to be used elsewhere.

This is helpful to protect certain operations that may involve more than one read / write operation such as:
* Initializing an SSL socket which has it's own negotiation sequence involving multiple reads and writes
* Reading a response of a variable size (such as when using `BinData::Record#read`)

I'll have a PR requiring these changes up shortly that'll show them in action.