### PR TITLE
Add the stopwatch function

### DIFF
--- a/lib/rex/stopwatch.rb
+++ b/lib/rex/stopwatch.rb
@@ -1,0 +1,18 @@
+module Rex
+
+  # This provides a correct way to time an operation provided within a block.
+  #
+  # @see https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/
+  #
+  # @yield [] The block whose operation should be timed.
+  #
+  # @return Returns the result of the block and the elapsed time in seconds.
+  def self.stopwatch
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    ret = yield
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+
+    [ret, elapsed]
+  end
+
+end


### PR DESCRIPTION
This adds a convenient wrapper function to correctly time the duration of operations. This can, for example, be used to calculate how long a server takes to respond in an exploit's check method.
