### PR TITLE
Refactor into a Stopwatch module

### DIFF
--- a/lib/rex/stopwatch.rb
+++ b/lib/rex/stopwatch.rb
@@ -3,14 +3,19 @@ module Rex::Stopwatch
   # This provides a correct way to time an operation provided within a block.
   #
   # @see https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/
+  # @see https://ruby-doc.org/core-2.7.1/Process.html#method-c-clock_gettime
+  #
+  # @param [Symbol] unit The unit of time in which to measure the duration. The
+  #   argument is passed to Process.clock_gettime which defines the acceptable
+  #   values.
   #
   # @yield [] The block whose operation should be timed.
   #
-  # @return Returns the result of the block and the elapsed time in seconds.
-  def self.elapsed_seconds
-    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  # @return Returns the result of the block and the elapsed time in the specified unit.
+  def self.elapsed_time(unit: :float_second)
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC, unit)
     ret = yield
-    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC, unit) - start
 
     [ret, elapsed]
   end


### PR DESCRIPTION
Renames the `stopwatch` function into `elapsed_time` under the `Stopwatch` module. Idea proposed by @adfoster-r7 [here](https://github.com/rapid7/rex-core/pull/17#discussion_r749763550). The time unit is adjustable and defaults to `:float_seconds`.

~~If we wanted more options on the unit, we can add `elapsed_time` in the future, and forward to `elapsed_seconds`. For now, it's easy enough to use arithmetic for the unit conversion.~~