### PR TITLE
Prevent :dup attempts on refcounted objects

### DIFF
--- a/lib/rex/sync/ref.rb
+++ b/lib/rex/sync/ref.rb
@@ -32,6 +32,10 @@ module Ref
     self
   end
 
+  # Prevent duplication of stateful reference counted objects such
+  # as those performed by :replicant Scanner mixin
+  alias :dup :ref
+
   #
   # Decrements the total number of references.  If the reference count
   # reaches zero, true is returned.  Otherwise, false is returned.


### PR DESCRIPTION
During development of the [LDAP service for log4j efforts](https://github.com/rapid7/metasploit-framework/pull/15961), a change
in the code after my unfortunate/inadvertent departure from daily
operations in Framework surfaced in the interaction between low
level Rex::ServiceManager objects and the Scanner mixin. The mixin
uses a "new" method called :replicant which appears to assume that
all instance variables in a MetasploitModule are without state and
can therefore be :dup'd without safety latches. At least when it
comes to Rex' services, this is usually not the case as that level
of infrastructure tends to handle system resource abstractions such
as bound/listening sockets which cannot be duplicated. The result
of this interaction is "loss" of service references such that the
originally started service cannot be accessed by any means from
within the framework but is still bound to the sockets, preventing
their use until Ruby is shut down.

After reviewing the issue with @Op3n4M3, @zeroSteiner, and other
members of the R7 team, two viable architectura approaches were
identified:
1. Rewrite the :replicant logic to account for state in the vars
which it duplicates. This is fraught and dangerous - the effort to
implement this was heroic in itself (we, the community, have had
that feature request in the air since long before R7 bought MSF).
2. Dig down deeper into the core and identify interception points
for the breaking :dup call and attempt to mitigate there.

Given that option 1 would still permit another caller to dup the
unique object, this commit targets option 2 by aliasing the :dup
method to the :ref method in the Ref mixin which is part of the
Rex::Service extension applied by Rex::ServiceManager during its
:start call.

Testing: not enough - this could have wide-ranging impacts, break
all sorts of things because rex-core is... the core. Requesting
all hackers with clever ideas and a propensity for having Murphy's
Law impact all that they do to run this through its paces hard and
repeatedly.