### PR TITLE
Fix metasploit-framework#15968 (Multiple Socket Abstraction Bugs)

### DIFF
--- a/lib/rex/io/socket_abstraction.rb
+++ b/lib/rex/io/socket_abstraction.rb
@@ -53,6 +53,9 @@ module Rex
       #
       def cleanup_abstraction
         lsock.close if lsock and !lsock.closed?
+
+        monitor_thread.join if monitor_thread&.alive?
+
         rsock.close if rsock and !rsock.closed?
 
         self.lsock = nil
@@ -159,10 +162,10 @@ module Rex
                   # Using syswrite() breaks SSL streams.
                   sent = write(data)
 
-                  # sf: Only remove the data off the queue is write was successfull.
-                  #     This way we naturally perform a resend if a failure occured.
+                  # sf: Only remove the data off the queue is write was successful.
+                  #     This way we naturally perform a resend if a failure occurred.
                   #     Catches an edge case with meterpreter TCP channels where remote send
-                  #     failes gracefully and a resend is required.
+                  #     fails gracefully and a resend is required.
                   if sent.nil?
                     closed = true
                     wlog('monitor_rsock: failed writing, socket must be dead')
@@ -182,7 +185,7 @@ module Rex
 
             begin
               close_write if respond_to?('close_write')
-            rescue IOError
+            rescue StandardError
             end
             break
           end

--- a/lib/rex/io/stream_server.rb
+++ b/lib/rex/io/stream_server.rb
@@ -141,7 +141,7 @@ module Rex
           begin
             cli = accept
             unless cli
-              elog("The accept() returned nil in stream server listener monitor:  #{fd.inspect}")
+              elog('The accept() returned nil in stream server listener monitor')
               ::IO.select(nil, nil, nil, 0.10)
               next
             end


### PR DESCRIPTION
This fixes multiple issues I ran into while working on rapid7/metasploit-framework#15968. I also ran rubocop on the two files which accounts for quite a few of their changes. Each was done in a dedicated commit, so hopefully that will help isolate those changes from the actual fixes.

The core of the issues results in a users inability to open a reverse_http Meterpreter session over a pivot/port-forward. A user should be able to either start a local handler and portforward to it via Meterpreter or start a handler via a Meterpreter session directly (using the `ReverseListenerComm` datastore option). Without these changes, the Meterpreter session would consistently fail to be established. The user would see that the stage was being sent, but the session would never be fully opened and responsive. I tracked the issue down to the socket abstraction that would close the connection before the entire HTTP response had been sent due to a race condition.

## Testing
- [ ] Open a Meterpreter session or an SSH session, one that's capable of starting port forwards (GatewayPorts must be enabled for SSH)
- [ ] Use a Meterpreter payload with a reverse_http stager (Windows and Python were tested while working on this PR)
- [ ] Configure the payload to start a handler using the session opened in step 1
    - [ ] Set LHOST to an IP address on the promised host
    - [ ] Set ReverseListenerComm to the session ID (note that the `-1` shortcut does not [work yet](https://github.com/rapid7/metasploit-framework/pull/16096))
    - [ ] Start the handler and generate a payload
    - [ ] Execute the payload and see a functioning Meterpreter session has been established
        * At this point, without these changes, the sending stage message would be shown but the session would never work. The original bug can be reproduced in this way.

The original issue mentioned using an explicit `portfwd`. While not strictly necessary to exercise the applicable code path, you can do so by modifying the steps to star the handler on the local Metasploit host and using a Meterpreter session opened in step 1 to start a reverse portforward. An SSH session won't work for this purpose because a single port can be forward since the `portfwd` command is a Meterpreter-specific command.