### PR TITLE
Rex::Compat: open_browser: Prepend 'file://' to file URLs for Android

### DIFF
--- a/lib/rex/compat.rb
+++ b/lib/rex/compat.rb
@@ -133,6 +133,7 @@ def self.open_browser(url='http://google.com/')
   when /darwin/
     system("open #{url}")
   when /android/
+    url = "file://#{url}" if url.to_s.start_with?('/')
     system("am start --user 0 -a android.intent.action.VIEW -d #{url}")
   else
     # Search through the PATH variable (if it exists) and chose a browser
@@ -190,6 +191,7 @@ def self.open_webrtc_browser(url='http://google.com/')
       end
     end
   when /android/
+    url = "file://#{url}" if url.to_s.start_with?('/')
     system("am start --user 0 -a android.intent.action.VIEW -d #{url}")
   else
     if defined? ENV['PATH']


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/12163. Maybe. Untested.

See https://github.com/rapid7/metasploit-framework/issues/12163#issuecomment-1065964384 for context.

---

Testing `am start` commands in an emulator confirms that the `file:///` URL scheme is required.

```
generic_x86_arm:/ $ am start --user 0 -a android.intent.action.VIEW -d /sdcard/Download/googlelogo_color_160x56dp.png                                                                   
Starting: Intent { act=android.intent.action.VIEW dat=/sdcard/Download/googlelogo_color_160x56dp.png }
Error: Activity not started, unable to resolve Intent { act=android.intent.action.VIEW dat=/sdcard/Download/googlelogo_color_160x56dp.png flg=0x10000000 }
generic_x86_arm:/ $ am start --user 0 -a android.intent.action.VIEW -d file:///sdcard/Download/googlelogo_color_160x56dp.png                                                            
Starting: Intent { act=android.intent.action.VIEW dat=file:///sdcard/Download/googlelogo_color_160x56dp.png }
```

However, the image file is opened in an incorrect program unless the `-t` flag is supplied with an appropriate type value.

```                                                    
generic_x86_arm:/ $ am start --user 0 -a android.intent.action.VIEW -d file:///sdcard/Download/googlelogo_color_160x56dp.png -t image/png
Starting: Intent { act=android.intent.action.VIEW dat=file:///sdcard/Download/googlelogo_color_160x56dp.png typ=image/png }
```

---

Seems like this might be insufficient for Termux. This comment https://github.com/termux/termux-packages/issues/7437#issuecomment-908724189 implies something like the following is required, which specifies the type with `-t` and temporary URI permissions with `--grant-read-uri-permission com.fstop.photo`:

```
am start --user 0 -a android.intent.action.VIEW -d content://com.termux.files/data/data/com.termux/files/home/downloads/Deep.png -t "image/*" --grant-read-uri-permission com.fstop.photo
```