### PR TITLE
Update Ubuntu 18.04 to 20.04 in Github CI script

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,24 +10,29 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 40
 
     strategy:
       fail-fast: true
       matrix:
         ruby:
-          - 2.6
           - 2.7
           - 3.0
           - 3.1
+        os:
+          - ubuntu-20.04
+          - ubuntu-latest
+        exclude:
+          - { os: ubuntu-latest, ruby: 2.7 }
+          - { os: ubuntu-latest, ruby: 3.0 }
         test_cmd:
           - bundle exec rspec
 
     env:
       RAILS_ENV: test
 
-    name: Ruby ${{ matrix.ruby }} - ${{ matrix.test_cmd }}
+    name: ${{ matrix.os }} - Ruby ${{ matrix.ruby }} - ${{ matrix.test_cmd }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Updates Github CI script to run 20.04 for now as Ubuntu 18.04 [EOL](https://endoflife.software/operating-systems/linux/ubuntu) was announced, updating early to avoid confusion with the brownout period:

> This is a scheduled Ubuntu-18.04 brownout. The Ubuntu-18.04 environment is deprecated and will be removed on December 1st, 2022. For more details, see https://github.com/actions/runner-images/issues/6002

Also removes Ruby 2.6 support, as it's officially end of life:
https://www.ruby-lang.org/en/downloads/branches/