### PR TITLE
Require DISPLAY environment variable for opening paths

### DIFF
--- a/lib/rex/compat.rb
+++ b/lib/rex/compat.rb
@@ -138,7 +138,9 @@ def self.open_browser(url='http://google.com/')
   else
     # Search through the PATH variable (if it exists) and chose a browser
     # We are making an assumption about the nature of "PATH" so tread lightly
-    if defined? ENV['PATH']
+    #
+    # If DISPLAY is not set, most unix graphical tools will not work.
+    if ENV['PATH'] && ENV['DISPLAY']
       # "xdg-open" is more general than "sensible-browser" and can be useful for lots of
       # file types -- text files, pcaps, or URLs. It's nearly always
       # going to use the application the user is expecting. If we're not
@@ -194,7 +196,8 @@ def self.open_webrtc_browser(url='http://google.com/')
     url = "file://#{url}" if url.to_s.start_with?('/')
     system("am start --user 0 -a android.intent.action.VIEW -d #{url}")
   else
-    if defined? ENV['PATH']
+    # If DISPLAY is not set, most unix graphical tools will not work.
+    if ENV['PATH'] && ENV['DISPLAY']
       ['google-chrome', 'chrome', 'chromium', 'firefox' , 'firefox', 'opera'].each do |browser|
         ENV['PATH'].split(':').each do |path|
           browser_path = "#{path}/#{browser}"


### PR DESCRIPTION
When display is not set and open_browser or open_webrtc_browser is called, various warnings can appear such as:

```
3.0.2 :002 > Rex::Compat.open_browser
 => nil 
3.0.2 :003 > [6516:6516:0916/113909.655962:ERROR:ozone_platform_x11.cc(247)] Missing X server or $DISPLAY
[6516:6516:0916/113909.656025:ERROR:env.cc(226)] The platform failed to initialize.  Exiting.
```

Or:
```
Error: no "view" rule for type "inode/directory" passed its test case
       (for more information, add "--debug=1" on the command line)
/usr/bin/xdg-open: 851: /usr/bin/xdg-open: www-browser: not found
/usr/bin/xdg-open: 851: /usr/bin/xdg-open: links2: not found
```

### Before

Display is not set, and warnings are generated:

```
➜  rex-core git:(upstream-master) bundle exec irb
3.0.2 :001 > require 'rex/compat'
 => true 
3.0.2 :002 > Rex::Compat.open_browser
 => nil 
3.0.2 :003 > [6516:6516:0916/113909.655962:ERROR:ozone_platform_x11.cc(247)] Missing X server or $DISPLAY
[6516:6516:0916/113909.656025:ERROR:env.cc(226)] The platform failed to initialize.  Exiting.
```

### After

If display is not set, no browser opens:

```
➜  rex-core git:(require-display-environment-variable-for-opening-paths) bundle exec irb
3.0.2 :001 > require 'rex/compat'
 => true 
3.0.2 :002 > Rex::Compat.open_browser
 => nil 
```