### PR TITLE
Allow developer configurable messages in exceptions

### DIFF
--- a/lib/rex/exceptions.rb
+++ b/lib/rex/exceptions.rb
@@ -18,8 +18,8 @@ end
 class TimeoutError < Interrupt
   include Exception
 
-  def to_s
-    "Operation timed out."
+  def initialize(msg = "Operation timed out.")
+    super(msg)
   end
 end
 
@@ -32,8 +32,8 @@ end
 class NotImplementedError < ::NotImplementedError
   include Exception
 
-  def to_s
-    "The requested method is not implemented."
+  def initialize(msg = "The requested method is not implemented.")
+    super(msg)
   end
 end
 
@@ -76,8 +76,8 @@ end
 class ArgumentParseError < ::ArgumentError
   include Exception
 
-  def to_s
-    "The argument could not be parsed correctly."
+  def initialize(msg = "The argument could not be parsed correctly.")
+    super(msg)
   end
 end
 

--- a/spec/rex/exceptions_spec.rb
+++ b/spec/rex/exceptions_spec.rb
@@ -1,0 +1,58 @@
+require 'rspec'
+require 'rex/exceptions'
+
+RSpec.shared_examples 'Rex::Exception#to_s' do
+  it 'provides a default error message' do
+    expect(described_class.new.to_s).to eq(default_exception_message)
+  end
+
+  it 'allows setting a custom error message' do
+    expect(described_class.new('custom message').to_s).to eq('custom message')
+  end
+
+  it 'defaults to the default message when the custom message is nil' do
+    expect(described_class.new(nil).to_s).to eq(described_class.to_s)
+  end
+end
+
+RSpec.describe Rex do
+  describe Rex::TimeoutError do
+    it_behaves_like 'Rex::Exception#to_s' do
+      let(:default_exception_message) do
+        'Operation timed out.'
+      end
+    end
+  end
+
+  describe Rex::NotImplementedError do
+    it_behaves_like 'Rex::Exception#to_s' do
+      let(:default_exception_message) do
+        'The requested method is not implemented.'
+      end
+    end
+  end
+
+  describe Rex::RuntimeError do
+    it_behaves_like 'Rex::Exception#to_s' do
+      let(:default_exception_message) do
+        described_class.to_s
+      end
+    end
+  end
+
+  describe Rex::ArgumentParseError do
+    it_behaves_like 'Rex::Exception#to_s' do
+      let(:default_exception_message) do
+        'The argument could not be parsed correctly.'
+      end
+    end
+  end
+
+  describe Rex::ArgumentParseError do
+    it_behaves_like 'Rex::Exception#to_s' do
+      let(:default_exception_message) do
+        'The argument could not be parsed correctly.'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Spotted as part of https://github.com/rapid7/metasploit-framework/pull/17455
Similar PR that was implemented in framework way-back-when: https://github.com/rapid7/metasploit-framework/pull/13367

### Before

Developer provided messages in exceptions are ignored:

```
$ bundle exec ruby -e 'require "rex/exceptions"; puts Rex::TimeoutError.new("Kerberos Client: failed to read response length due to timeout").to_s'
Operation timed out.
```

### After

Developer provided messages in exceptions are correctly tracked

```
$ bundle exec ruby -e 'require "rex/exceptions"; puts Rex::TimeoutError.new("Kerberos Client: failed to read response length due to timeout").to_s'
Kerberos Client: failed to read response length due to timeout
```