### PR TITLE
Fix Ruby version strings in verify.yml so they are properly quoted

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,10 +17,10 @@ jobs:
       fail-fast: true
       matrix:
         ruby:
-          - 2.6
-          - 2.7
-          - 3.0
-          - 3.1
+          - '2.6'
+          - '2.7'
+          - '3.0'
+          - '3.1'
         test_cmd:
           - bundle exec rspec
 
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
 
       - name: ${{ matrix.test_cmd }}


### PR DESCRIPTION
This addresses items related to https://github.com/rapid7/metasploit-framework/pull/17419 but applies them to the rex-core repository. TLDR: All version strings in YAML should be quoted unless you want bad things to happen.