### PR TITLE
Add support for Windows Ruby ucrt

### DIFF
--- a/lib/rex/compat.rb
+++ b/lib/rex/compat.rb
@@ -35,10 +35,10 @@ ENABLE_PROCESSED_INPUT = 1
 @@loaded_tempfile  = false
 @@loaded_fileutils = false
 
-
 def self.is_windows
   return @@is_windows if @@is_windows
-  @@is_windows = (RUBY_PLATFORM =~ /mswin(32|64)|mingw(32|64)/) ? true : false
+  # Additionally detect x64-mingw-ucrt - https://rubyinstaller.org/2022/11/27/rubyinstaller-3.1.3-1-3.0.5-1-and-2.7.7-1-released.html
+  @@is_windows = (RUBY_PLATFORM =~ /mswin(32|64)|mingw(32|64|\-ucrt)/) ? true : false
 end
 
 def self.is_cygwin

--- a/spec/rex/compat_spec.rb
+++ b/spec/rex/compat_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Rex::Compat do
+  describe ".is_windows" do
+    before(:each) do
+      described_class.class_variable_set(:@@is_windows, false)
+    end
+
+    [
+      { ruby_platform: 'x64-mingw32', expected: true },
+      { ruby_platform: 'x64-mingw-ucrt', expected: true },
+      { ruby_platform: 'x86_64-darwin20', expected: false },
+    ].each do |test|
+      it "correctly identifies #{test[:ruby_platform]} as windows=#{test[:expected]}" do
+        stub_const('RUBY_PLATFORM', test[:ruby_platform])
+        expect(described_class.is_windows).to eq test[:expected]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ruby 3.0:

![image](https://github.com/rapid7/rex-core/assets/60357436/1c954830-55bf-4e98-bdaa-e467bf2841ba)

Ruby 3.1:

![image](https://github.com/rapid7/rex-core/assets/60357436/8c847ef9-d7b7-4e64-80ae-22165952929a)

I need this method updated, so that msfconsole can print out color via the Reex::text color helpers

Rex::Text Helper:

https://github.com/rapid7/rex-text/blob/843bedf83c44f7c36bbcfaf05b3c2fa49f9d4f28/lib/rex/text/color.rb#L102-L104

`supports_color?` implementation

https://github.com/rapid7/metasploit-framework/blob/f6e7aacfb5e3724c15b1ed7373522ad071561bc8/lib/rex/ui/text/output/stdio.rb#L98-L112