### PR TITLE
Add and use #reset!

### DIFF
--- a/lib/rex/io/fiber_scheduler.rb
+++ b/lib/rex/io/fiber_scheduler.rb
@@ -133,6 +133,18 @@ module IO
       @urgent.nil?
     end
 
+    def reset!
+      @mutex.synchronize do
+        @readable.clear
+        @writable.clear
+        @waiting.clear
+        @ready.clear
+        @pending.clear
+        @blocking = 0
+        @urgent = Rex::Compat.pipe
+      end
+    end
+
     def fiber(&block)
       fiber = Fiber.new(blocking: false, &block)
       fiber.resume

--- a/lib/rex/io/relay_manager.rb
+++ b/lib/rex/io/relay_manager.rb
@@ -70,6 +70,7 @@ class RelayManager
     @scheduler.run
   ensure
     Fiber.set_scheduler(old_scheduler)
+    @scheduler.reset!
   end
 
   def relay_fiber(sock, sink, name, on_exit: nil)


### PR DESCRIPTION
This adds a `#reset!` method to the `FiberScheduler` class, which will reset the object back to its initial state. This is necessary if the scheduler will be used again as is the case in the RelayManager. If one or more relays are added then they all exit, the scheduler needs to be reset before it can be used again. This fixes a bug where the relays all exit, then more relays are added. Between the exit of the original relays and the new ones being added, the scheduler was left in a closed state so the new relays were never being processed.